### PR TITLE
Handle pre-selected row items properly; storybook actions console log addon

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,5 @@
+import '@storybook/addon-console';
+
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   docs: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/coreui",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "author": "Michael Dunn <mdunn4@nd.edu>",
   "description": "Core components and style definitions for VEuPath applications.",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@emotion/babel-plugin": "^11.3.0",
     "@emotion/babel-preset-css-prop": "^11.2.0",
     "@storybook/addon-actions": "^6.4.19",
+    "@storybook/addon-console": "^1.2.3",
     "@storybook/addon-essentials": "^6.4.19",
     "@storybook/addon-links": "^6.4.19",
     "@storybook/react": "^6.4.19",

--- a/src/components/grids/DataGrid/index.tsx
+++ b/src/components/grids/DataGrid/index.tsx
@@ -180,11 +180,15 @@ export default function DataGrid({
               </div>
             ),
             // The cell can use the individual row's getToggleRowSelectedProps method
-            // to the render a checkbox
+            // to the render a checkbox.
+	    // The `checked` prop returned by getToggleRowSelectedProps is not fit for purpose
+	    // because it only considers initial pre-selected/checked state (originalData[].isSelected).
+	    // Luckily `row.isSelected` has the correct "live" state.
             Cell: ({ row }) => (
               <div>
                 <IndeterminateCheckbox
                   {...row.getToggleRowSelectedProps()}
+	          checked={row.isSelected}
                   themeRole={themeRole}
                 />
               </div>

--- a/src/components/grids/DataGrid/index.tsx
+++ b/src/components/grids/DataGrid/index.tsx
@@ -130,6 +130,8 @@ export default function DataGrid({
     previousPage,
     setPageSize,
     state: { pageIndex, pageSize, selectedRowIds },
+    rows,
+    toggleRowSelected,
   } = useTable(
     {
       columns,
@@ -212,6 +214,16 @@ export default function DataGrid({
     onRowSelection && onRowSelection(selectedFlatRows);
   }, [selectedFlatRows]);
 
+  // Fix from https://github.com/TanStack/react-table/issues/2459#issuecomment-851523333
+  // to properly set selected state from incoming `isSelected` prop in data
+  useEffect(() => {
+    rows.forEach(({ id, original } : {id: string, original: { isSelected?: boolean }}) => {
+      if (original.isSelected != null) {
+	toggleRowSelected(id, original.isSelected);
+      }
+    });
+  }, [rows, toggleRowSelected]);
+  
   return (
     <div>
       {title && <H3 text={title} additionalStyles={{ marginBottom: 20 }} />}

--- a/src/stories/grids/DataGrid.stories.tsx
+++ b/src/stories/grids/DataGrid.stories.tsx
@@ -20,7 +20,8 @@ export default {
   component: DataGrid,
 } as Meta;
 
-const Template: Story<DataGridProps> = (args) => (
+const Template: Story<DataGridProps> = (args) => {
+  return (
   <UIThemeProvider
     theme={{
       palette: {
@@ -29,9 +30,12 @@ const Template: Story<DataGridProps> = (args) => (
       },
     }}
   >
-    <DataGrid {...args} columns={columns({ role: args.themeRole })} />
+    <DataGrid {...args} columns={columns({ role: args.themeRole })}/>
   </UIThemeProvider>
-);
+  );
+};
+
+
 export const Basic = Template.bind({});
 Basic.args = {
   title: 'Basic Data Grid',
@@ -56,13 +60,30 @@ WithPagination.args = {
   },
 };
 
+const reportSelectedRows = (rows) => console.log(`checked rows: ${rows.map((row) => row.original.record_id)}`);
+
 export const WithRowSelection = Template.bind({});
 WithRowSelection.args = {
   ...Basic.args,
-  onRowSelection: (rows) => console.log('Rows selected', rows),
+  onRowSelection: reportSelectedRows,
   title: 'Data Grid w/ Row Selection',
   pagination: {
     recordsPerPage: 2,
+    controlsLocation: 'bottom',
+  },
+};
+
+export const WithPreselectedRowSelection = Template.bind({});
+WithPreselectedRowSelection.args = {
+  ...Basic.args,
+  data: ROWS.map((row, index) => ({
+    ...row,
+    isSelected: index % 3 === 0,
+  })),
+  onRowSelection: reportSelectedRows,
+  title: 'Data Grid w/ Row Selection',
+  pagination: {
+    recordsPerPage: 10,
     controlsLocation: 'bottom',
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,6 +1725,13 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/addon-console@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-console/-/addon-console-1.2.3.tgz#f6c88a8f54fe00c8de9b77720eaef2bc1daa3af1"
+  integrity sha512-w5uCUwECA28fdZWoa+A4e/RS9XzBStdd3TwwmpSM5m4fjURJI7Qr+uVq30UeRdgZRH1K7CdWzYUE6RxWXMdVyw==
+  dependencies:
+    global "^4.3.2"
+
 "@storybook/addon-controls@6.4.19":
   version "6.4.19"
   resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-6.4.19.tgz#1ebf74f7b0843ea0eccd319f5295dfa48947a975"
@@ -5833,7 +5840,7 @@ glob@^7.0.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global@^4.4.0:
+global@^4.3.2, global@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
   integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==


### PR DESCRIPTION
Workaround for the issue reported here

https://github.com/TanStack/react-table/issues/2459#issuecomment-851523333

When you add `isSelected: true` to row items that you want to be selected already, it wasn't working properly, but now it is.