### PR TITLE
Use a darker text color for the "mesa" preset

### DIFF
--- a/src/components/grids/DataGrid/stylePresets.ts
+++ b/src/components/grids/DataGrid/stylePresets.ts
@@ -41,7 +41,7 @@ const mesa: DataGridStyleSpec = {
     paddingRight: 30,
     paddingBottom: 10,
     paddingTop: 10,
-    color: gray[500],
+    color: gray[700],
     alignContent: 'center',
     backgroundColor: gray[100],
     fontSize: 13,
@@ -52,7 +52,7 @@ const mesa: DataGridStyleSpec = {
     borderLeft: 'solid 1px',
     borderRight: 'solid 1px',
     borderColor: gray[200],
-    color: gray[500],
+    color: gray[800],
     fontSize: 12,
   },
   icons: {

--- a/src/components/grids/DataGrid/stylePresets.ts
+++ b/src/components/grids/DataGrid/stylePresets.ts
@@ -41,7 +41,7 @@ const mesa: DataGridStyleSpec = {
     paddingRight: 30,
     paddingBottom: 10,
     paddingTop: 10,
-    color: gray[700],
+    color: gray[800],
     alignContent: 'center',
     backgroundColor: gray[100],
     fontSize: 13,


### PR DESCRIPTION
closes #72 

This PR adjusts the data cell text color for the "mesa" preset

Before:
![image](https://user-images.githubusercontent.com/365139/171941633-4a9a42e6-9ac8-451a-9698-b4b789980d27.png)

After:
![image](https://user-images.githubusercontent.com/365139/171941710-11df4046-f809-42c7-8316-6152234f5fc0.png)
