### PR TITLE
Refactor TabbedDisplay to remove internal state

### DIFF
--- a/src/components/grids/TabbedDisplay/index.tsx
+++ b/src/components/grids/TabbedDisplay/index.tsx
@@ -83,18 +83,18 @@ export default function TabbedDisplay({
   const [activeTabInternal, setActiveTabInternal] = useState(
     activeTab ?? tabs[0].displayName
   );
-
+  
   // Listen for changes to the `activeTab` prop. This allows the component
   // to be controlled programmatically.
   useEffect(() => {
-    if (activeTab && activeTab !== activeTabInternal) {
+    if (tabs && activeTab && activeTab !== activeTabInternal) {
       const matchingTabRecord = tabs.find(
         (tab) => tab.displayName === activeTab
       );
       matchingTabRecord && setActiveTabInternal(activeTab);
       matchingTabRecord?.onSelect && matchingTabRecord.onSelect();
     }
-  }, [activeTab]);
+  }, [tabs, activeTab]);
 
   const [hoveredTab, setHoveredTab] = useState<null | string>(null);
 
@@ -123,7 +123,11 @@ export default function TabbedDisplay({
   );
 
   const tabContent = useMemo(
-    () => tabs.find((tab) => tab.displayName === activeTabInternal)!.content,
+    () => {
+      if (tabs && activeTabInternal === activeTab) {
+        return tabs.find((tab) => tab.displayName === activeTabInternal)!.content
+      }
+    },
     [tabs, activeTabInternal]
   );
 

--- a/src/components/grids/TabbedDisplay/index.tsx
+++ b/src/components/grids/TabbedDisplay/index.tsx
@@ -57,7 +57,7 @@ export type TabbedDisplayProps = {
     displayName: string;
     content?: React.ReactNode;
   }>;
-  onClick: (tabDisplayName: string) => void;
+  onTabSelected: (selectedTabDisplayName: string) => void;
   /**
    * The value MUST be the displayName of one of the tabs. */
   activeTab: string;
@@ -73,11 +73,13 @@ export type TabbedDisplayProps = {
 export default function TabbedDisplay({
   tabs,
   activeTab,
-  onClick,
+  onTabSelected,
   styleOverrides = {},
   themeRole,
 }: TabbedDisplayProps) {
-  const tabContent = tabs.find(tab => tab.displayName === activeTab)!.content
+  const selectedTab = tabs.find(tab => tab.displayName === activeTab);
+  const tabContent = selectedTab ? selectedTab.content : null;
+
   const [hoveredTab, setHoveredTab] = useState<null | string>(null);
 
   const theme = useUITheme();
@@ -137,14 +139,14 @@ export default function TabbedDisplay({
                     'background-color .5s, border-color .5s, color .5s',
                 },
               ]}
-              onClick={() => onClick && onClick(tab.displayName)}
+              onClick={() => onTabSelected && onTabSelected(tab.displayName)}
               onFocus={() => setHoveredTab(tab.displayName)}
               onBlur={() => setHoveredTab(null)}
               onMouseOver={() => setHoveredTab(tab.displayName)}
               onMouseOut={() => setHoveredTab(null)}
               onKeyDown={(event) => {
                 if (['Space', 'Enter'].includes(event.code)) {
-                  onClick && onClick(tab.displayName);
+                  onTabSelected && onTabSelected(tab.displayName);
                 }
               }}
             >

--- a/src/components/grids/TabbedDisplay/index.tsx
+++ b/src/components/grids/TabbedDisplay/index.tsx
@@ -59,12 +59,8 @@ export type TabbedDisplayProps = {
   }>;
   onClick: (tabDisplayName: string) => void;
   /**
-   * Optional. If you want, you can use this prop to set the
-   * initially selected tab OR control the currently selected
-   * tab programatically.
-   *
    * The value MUST be the displayName of one of the tabs. */
-  activeTab?: string;
+  activeTab: string;
   /** Optional. Any desired style overrides. */
   styleOverrides?: Partial<TabbedDisplayStyleSpec>;
   /**
@@ -81,8 +77,7 @@ export default function TabbedDisplay({
   styleOverrides = {},
   themeRole,
 }: TabbedDisplayProps) {
-  const internalActiveTab = activeTab ?? tabs[0].displayName;
-  const tabContent = tabs.find(tab => tab.displayName === internalActiveTab)!.content
+  const tabContent = tabs.find(tab => tab.displayName === activeTab)!.content
   const [hoveredTab, setHoveredTab] = useState<null | string>(null);
 
   const theme = useUITheme();
@@ -118,7 +113,7 @@ export default function TabbedDisplay({
       >
         {tabs.map((tab) => {
           const tabState =
-            tab.displayName === internalActiveTab
+            tab.displayName === activeTab
               ? 'active'
               : tab.displayName === hoveredTab
               ? 'hover'

--- a/src/components/grids/TabbedDisplay/index.tsx
+++ b/src/components/grids/TabbedDisplay/index.tsx
@@ -57,6 +57,7 @@ export type TabbedDisplayProps = {
     displayName: string;
     content?: React.ReactNode;
   }>;
+  onClick: (tabDisplayName: string) => void;
   /**
    * Optional. If you want, you can use this prop to set the
    * initially selected tab OR control the currently selected
@@ -64,8 +65,6 @@ export type TabbedDisplayProps = {
    *
    * The value MUST be the displayName of one of the tabs. */
   activeTab?: string;
-  /** */
-  onClick?: (tabDisplayName: string) => void;
   /** Optional. Any desired style overrides. */
   styleOverrides?: Partial<TabbedDisplayStyleSpec>;
   /**
@@ -82,7 +81,8 @@ export default function TabbedDisplay({
   styleOverrides = {},
   themeRole,
 }: TabbedDisplayProps) {
-  const tabContent = tabs.find(tab => tab.displayName === activeTab)!.content
+  const internalActiveTab = activeTab ?? tabs[0].displayName;
+  const tabContent = tabs.find(tab => tab.displayName === internalActiveTab)!.content
   const [hoveredTab, setHoveredTab] = useState<null | string>(null);
 
   const theme = useUITheme();
@@ -118,7 +118,7 @@ export default function TabbedDisplay({
       >
         {tabs.map((tab) => {
           const tabState =
-            tab.displayName === activeTab
+            tab.displayName === internalActiveTab
               ? 'active'
               : tab.displayName === hoveredTab
               ? 'hover'


### PR DESCRIPTION
This refactored version is being used in the work for [this PR](https://github.com/VEuPathDB/ApiCommonWebsite/pull/69).