### PR TITLE
add theme-agnostic colors

### DIFF
--- a/src/components/banners/Banner.tsx
+++ b/src/components/banners/Banner.tsx
@@ -8,7 +8,7 @@ import InfoIcon from '@material-ui/icons/Info';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import CloseIcon from '@material-ui/icons/Close';
 
-import { gray, mutedGreen, orange, red, blue, ColorHue } from '../../definitions/colors';
+import { gray, warning, error, success, blue, ColorHue } from '../../definitions/colors';
 
 export type BannerProps = {
   type: 'warning' | 'danger' | 'error' | 'success' | 'info' | 'normal';
@@ -42,13 +42,13 @@ function getIconComponentFromType(type: BannerProps['type']) {
 function getColorTheme(type: BannerProps['type'], weight: keyof ColorHue) {
   switch (type) {
     case 'warning':
-      return orange[weight];
+      return warning[weight];
     case 'danger':
-      return red[weight];
+      return error[weight];
     case 'error':
-      return gray[weight];
+      return error[weight];
     case 'success':
-      return mutedGreen[weight];
+      return success[weight];
     case 'info':
       return blue[weight];
     case 'normal':

--- a/src/components/notifications/SnackbarProvider.tsx
+++ b/src/components/notifications/SnackbarProvider.tsx
@@ -12,9 +12,9 @@ import {
 import {
   ColorHue,
   mutedBlue,
-  mutedGreen,
-  mutedRed,
-  mutedYellow
+  success,
+  error,
+  warning
 } from '../../definitions/colors';
 import { UITheme, useUITheme } from '../theming';
 
@@ -42,9 +42,9 @@ export default function makeSnackbarProvider<
   displayName: string = 'SnackbarProvider'
 ) {
   const useStyles = makeStyles({
-    variantSuccess: makeSnackbarVariantStyles(mutedGreen),
-    variantError: makeSnackbarVariantStyles(mutedRed),
-    variantWarning: makeSnackbarVariantStyles(mutedYellow),
+    variantSuccess: makeSnackbarVariantStyles(success),
+    variantError: makeSnackbarVariantStyles(error),
+    variantWarning: makeSnackbarVariantStyles(warning),
     variantInfo({ theme }) {
       return makeSnackbarVariantStyles(
         theme?.palette.primary.hue ?? mutedBlue

--- a/src/definitions/colors.ts
+++ b/src/definitions/colors.ts
@@ -257,7 +257,7 @@ export const mutedPurple: ColorHue = {
   900: '#2D1339',
 };
 
-// Theme-agnostic colors
+// Alert colors
 export const warning: ColorHue = {
   100: '#FDF7E7',
   200: '#F9E7B8',

--- a/src/definitions/colors.ts
+++ b/src/definitions/colors.ts
@@ -257,6 +257,43 @@ export const mutedPurple: ColorHue = {
   900: '#2D1339',
 };
 
+// Theme-agnostic colors
+export const warning: ColorHue = {
+  100: '#FDF7E7',
+  200: '#F9E7B8',
+  300: '#F5D78A',
+  400: '#FFCC4D',
+  500: '#ECAE13',
+  600: '#BD8C0F',
+  700: '#8E690B',
+  800: '#5E4608',
+  900: '#473406',
+};
+
+export const error: ColorHue = {
+  100: '#FFE7E5',
+  200: '#FFB8B2',
+  300: '#FF8880',
+  400: '#FF584D',
+  500: '#FF1100',
+  600: '#CC0E00',
+  700: '#990A00',
+  800: '#660700',
+  900: '#4D0500',
+};
+
+export const success: ColorHue = {
+  100: '#EBFAEB',
+  200: '#C3EFC3',
+  300: '#9BE49B',
+  400: '#73D973',
+  500: '#37C837',
+  600: '#2CA02C',
+  700: '#217821',
+  800: '#165016',
+  900: '#103C10',
+};
+
 export default {
   white,
   black,
@@ -280,4 +317,7 @@ export default {
   mutedMagenta,
   purple,
   mutedPurple,
+  warning,
+  error,
+  success
 };


### PR DESCRIPTION
This PR adds the three alert colors. 

The goal here is to simply add the colors and swap them into `Banner` and `Snackbar` where appropriate. I'm leaving other related design changes to these components to a separate PR.