### PR TITLE
Add styleOverrides for TabbedDisplay's tab labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/coreui",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "author": "Michael Dunn <mdunn4@nd.edu>",
   "description": "Core components and style definitions for VEuPath applications.",
   "private": false,

--- a/src/components/grids/TabbedDisplay/index.tsx
+++ b/src/components/grids/TabbedDisplay/index.tsx
@@ -19,7 +19,7 @@ export type TabbedDisplayStyleSpec = {
   inactive: TabStyle;
   active: TabStyle;
   hover: TabStyle;
-  tabLabel: CSSProperties;
+  tabFontSize: CSSProperties['fontSize'];
 };
 
 const DEFAULT_STYLE: TabbedDisplayStyleSpec = {
@@ -44,10 +44,7 @@ const DEFAULT_STYLE: TabbedDisplayStyleSpec = {
     textColor: gray[400],
     indicatorColor: tan[300],
   },
-  tabLabel: {
-    fontSize: '1em',
-    margin: 0,
-  }
+  tabFontSize: '1em',
 };
 
 export type TabbedDisplayProps<TabKey extends string> = {
@@ -158,15 +155,15 @@ export default function TabbedDisplay<T extends string = string>({
                 }
               }}
             >
-              <span
+              <div
                 css={{
-                  ...finalStyle.tabLabel,
+                  fontSize: finalStyle.tabFontSize,
                   color: finalStyle[tabState].textColor,
                   fontWeight: tab.key === activeTab ? 'bold' : 'normal',
                 }}
               >
                 {tab.displayName}
-              </span>
+              </div>
             </div>
           );
         })}

--- a/src/components/grids/TabbedDisplay/index.tsx
+++ b/src/components/grids/TabbedDisplay/index.tsx
@@ -1,8 +1,5 @@
-import { useMemo, useState, CSSProperties, useEffect } from 'react';
+import { useMemo, useState, CSSProperties } from 'react';
 import { merge } from 'lodash';
-
-// Components
-import { H6 } from '../../typography';
 
 // Definitions
 import { blue, gray, tan } from '../../../definitions/colors';
@@ -22,6 +19,7 @@ export type TabbedDisplayStyleSpec = {
   inactive: TabStyle;
   active: TabStyle;
   hover: TabStyle;
+  tabLabel: CSSProperties;
 };
 
 const DEFAULT_STYLE: TabbedDisplayStyleSpec = {
@@ -29,6 +27,7 @@ const DEFAULT_STYLE: TabbedDisplayStyleSpec = {
     display: 'flex',
     flexDirection: 'column',
     boxSizing: 'border-box',
+    margin: 0,
   },
   active: {
     backgroundColor: blue[100],
@@ -45,6 +44,10 @@ const DEFAULT_STYLE: TabbedDisplayStyleSpec = {
     textColor: gray[400],
     indicatorColor: tan[300],
   },
+  tabLabel: {
+    fontSize: '1em',
+    margin: 0,
+  }
 };
 
 export type TabbedDisplayProps<TabKey extends string> = {
@@ -155,11 +158,15 @@ export default function TabbedDisplay<T extends string = string>({
                 }
               }}
             >
-              <H6
-                children={tab.displayName}
-                additionalStyles={{ margin: 0 }}
-                color={finalStyle[tabState].textColor}
-              />
+              <span
+                css={{
+                  ...finalStyle.tabLabel,
+                  color: finalStyle[tabState].textColor,
+                  fontWeight: tab.key === activeTab ? 'bold' : 'normal',
+                }}
+              >
+                {tab.displayName}
+              </span>
             </div>
           );
         })}


### PR DESCRIPTION
There was feedback on an implementation of `TabbedDisplay` that requested increasing the font size of the tab labels. As a result, the `styleOverrides` have been adjusted to allow for such alterations. Also, the `H6` component that was used for the tab label has been replaced with a more semantically-appropriate `<span>` element.