### PR TITLE
Remove textTransform from DataGrid's headerCells default CSS

### DIFF
--- a/src/components/grids/DataGrid/stylePresets.ts
+++ b/src/components/grids/DataGrid/stylePresets.ts
@@ -54,7 +54,6 @@ const mesa: DataGridStyleSpec = {
     alignContent: 'center',
     backgroundColor: gray[100],
     fontSize: 13,
-    textTransform: 'capitalize',
   },
   dataCells: {
     padding: '10px',


### PR DESCRIPTION
There has been [recent discussion](https://github.com/VEuPathDB/web-eda/pull/1263#event-7059013173) about whether or not we should be transforming text on the client side. The general consensus seems to be: no, we should not.

Thus, I'm removing the `textTransform` default style from the `DataGrid` component's column headers.