### PR TITLE
Change npm release type from created to published

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,7 +5,7 @@ name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
There are [some peculiarities](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) around how the workflow for package releases are generated in regards to `published` versus `created`.

Hopefully this will resolve those peculiarities.

