### PR TITLE
Use yarn instead of npm in GitHub workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,9 +15,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
-      - run: npm install
-      - run: npm run build
-      - run: npm run tsc
+      - run: yarn install
+      - run: yarn build-npm-modules
       - name: Store Dist Folder
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Current workflow that publishes the `npm` package is using `npm` (shown below) whereas all other client repos use `yarn`.
```yml
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - uses: actions/setup-node@v2
        with:
          node-version: 14
      - run: npm install
      - run: npm run build
```