### PR TITLE
Tweak new CoreUI components during implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/coreui",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "author": "Michael Dunn <mdunn4@nd.edu>",
   "description": "Core components and style definitions for VEuPath applications.",
   "private": false,

--- a/src/components/inputs/SearchBox/SearchBox.tsx
+++ b/src/components/inputs/SearchBox/SearchBox.tsx
@@ -31,6 +31,7 @@ const defaultStyle = {
     width: '0.7em',
     height: '0.7em',
     marginLeft: '0.5em',
+    color: '#17b'
   },
   searchIcon: {
     width: '0.7em',

--- a/src/components/inputs/SelectList.tsx
+++ b/src/components/inputs/SelectList.tsx
@@ -18,10 +18,6 @@ export default function SelectList({
     defaultButtonDisplayContent,
 }: SelectListProps) {
     const [selected, setSelected] = useState<SelectListProps['value']>(value);
-    /** 
-     * this is essentially how Bob M. is handling this in his ad hoc ValuePicker for proportion controls
-     * if we desire to concat the values, we'll need to add ellipsis at a calculated length/width
-     * */ 
     const [ buttonDisplayContent, setButtonDisplayContent] = useState<ReactNode>(value.length ? value.join(', ') : defaultButtonDisplayContent);
 
     const onClose = () => {
@@ -29,19 +25,36 @@ export default function SelectList({
         setButtonDisplayContent(selected.length ? selected.join(', ') : defaultButtonDisplayContent);
     }
 
+    const buttonLabel = (
+        <span
+        style={{
+            maxWidth: '300px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+        }}
+        >
+        {buttonDisplayContent}
+        </span>
+    );
+
     return (
         <PopoverButton
-            buttonDisplayContent={buttonDisplayContent}
+            buttonDisplayContent={buttonLabel}
             onClose={onClose}
         >
-            <CheckboxList 
-                name={name}
-                items={items}
-                value={selected}
-                onChange={setSelected}
-                linksPosition={linksPosition}
-            />
-            {children}
+            <div css={{
+                margin: '0.5em'
+            }}>
+                <CheckboxList 
+                    name={name}
+                    items={items}
+                    value={selected}
+                    onChange={setSelected}
+                    linksPosition={linksPosition}
+                />
+                {children}
+            </div>
         </PopoverButton>
     )
 }

--- a/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
+++ b/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
@@ -22,24 +22,26 @@ export enum LinksPosition {
 }
 
 export type CheckboxTreeStyleSpec = {
-  links: {
+  treeLinks: {
     containerHeight: CSSProperties['height'],
-    fontSize: number,
-    background: CSSProperties['background'],
-    border: CSSProperties['border'],
+    containerMargin: CSSProperties['margin'],
+    fontSize: CSSProperties['fontSize'],
     color: CSSProperties['color'],
     textDecoration: CSSProperties['textDecoration'],
+    background: CSSProperties['background'],
+    border: CSSProperties['border'],
   },
 };
 
 const defaultStyle: CheckboxTreeStyleSpec = {
-  links: {
+  treeLinks: {
     containerHeight: '1.5em',
-    fontSize: 12,
-    background: 0,
-    border: 0,
+    containerMargin: '0.5em 0',
+    fontSize: '0.9em',
     color: '#069',
     textDecoration: 'default',
+    background: 0,
+    border: 0,
   },
 };
 
@@ -211,12 +213,17 @@ function TreeLinks({
 }: TreeLinksProps) {
 
   const linkStyles = {
-    ...defaultStyle.links,
+    ...defaultStyle.treeLinks,
     '&:hover': linksHoverDecoration,
   }
 
   return (
-    <div css={{display: 'flex', justifyContent: 'center', margin: '0.25em 0'}}>
+    <div css={{
+        display: 'flex',
+        justifyContent: 'center',
+        height: defaultStyle.treeLinks.containerHeight,
+        margin: defaultStyle.treeLinks.containerMargin,
+      }}>
 
       { isFiltered && showSelectionLinks &&
         <div>
@@ -790,6 +797,7 @@ function CheckboxTree<T> (props: CheckboxTreeProps<T>) {
           <div css={{
             display: 'flex',
             justifyContent: 'center',
+            columnGap: '1em',
           }}>
             <SearchBox
               autoFocus={autoFocusSearchBox}

--- a/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
+++ b/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
@@ -24,7 +24,7 @@ export enum LinksPosition {
 export type CheckboxTreeStyleSpec = {
   treeLinks: {
     containerHeight: CSSProperties['height'],
-    containerMargin: CSSProperties['margin'],
+    containerPadding: CSSProperties['padding'],
     fontSize: CSSProperties['fontSize'],
     color: CSSProperties['color'],
     textDecoration: CSSProperties['textDecoration'],
@@ -35,8 +35,8 @@ export type CheckboxTreeStyleSpec = {
 
 const defaultStyle: CheckboxTreeStyleSpec = {
   treeLinks: {
-    containerHeight: '1.5em',
-    containerMargin: '0.5em 0',
+    containerHeight: '2em',
+    containerPadding: '0.5em 0',
     fontSize: '0.9em',
     color: '#069',
     textDecoration: 'default',
@@ -222,7 +222,7 @@ function TreeLinks({
         display: 'flex',
         justifyContent: 'center',
         height: defaultStyle.treeLinks.containerHeight,
-        margin: defaultStyle.treeLinks.containerMargin,
+        padding: defaultStyle.treeLinks.containerPadding,
       }}>
 
       { isFiltered && showSelectionLinks &&

--- a/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
+++ b/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
@@ -216,7 +216,7 @@ function TreeLinks({
   }
 
   return (
-    <div css={{height: defaultStyle.links.containerHeight}}>
+    <div css={{display: 'flex', justifyContent: 'center', margin: '0.25em 0'}}>
 
       { isFiltered && showSelectionLinks &&
         <div>
@@ -756,37 +756,40 @@ function CheckboxTree<T> (props: CheckboxTreeProps<T>) {
     );
 
     let treeSection = (
-      <ul css={{width: '100%', margin: '0.5em 0', padding: '0 1em', alignSelf: 'flex-start'}}>
-      {topLevelNodes.map((node, index) => {
-        const nodeId = getNodeId(node);
+      <div css={{flexGrow: 2, overflowY: 'auto'}}>
+        <ul css={{width: '100%', margin: '0.5em 0', padding: '0 1em', alignSelf: 'flex-start'}}>
+          {topLevelNodes.map((node, index) => {
+            const nodeId = getNodeId(node);
 
-        return <CheckboxTreeNode
-          key={"node_" + nodeId}
-          name={name || ''}
-          node={node}
-          path={[index]}
-          getNodeState={getNodeState}
-          isSelectable={!!isSelectable}
-          isMultiPick={!!isMultiPick}
-          isActiveSearch={isActiveSearch(props)}
-          toggleSelection={toggleSelection}
-          toggleExpansion={toggleExpansion}
-          shouldExpandOnClick={shouldExpandOnClick}
-          getNodeId={getNodeId}
-          getNodeChildren={getStatefulChildren}
-          renderNode={renderNode}
-          customCheckboxes={customCheckboxes as unknown as CustomCheckboxes<StatefulNode<T>>} />
-        })
-      }
-    </ul>
+            return <CheckboxTreeNode
+              key={"node_" + nodeId}
+              name={name || ''}
+              node={node}
+              path={[index]}
+              getNodeState={getNodeState}
+              isSelectable={!!isSelectable}
+              isMultiPick={!!isMultiPick}
+              isActiveSearch={isActiveSearch(props)}
+              toggleSelection={toggleSelection}
+              toggleExpansion={toggleExpansion}
+              shouldExpandOnClick={shouldExpandOnClick}
+              getNodeId={getNodeId}
+              getNodeChildren={getStatefulChildren}
+              renderNode={renderNode}
+              customCheckboxes={customCheckboxes as unknown as CustomCheckboxes<StatefulNode<T>>} />
+            })
+          }
+        </ul>
+      </div>
     )
 
     return (
-      <div css={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
+      <>
         {linksPosition && linksPosition == LinksPosition.Top ? treeLinks : null}
         {!isSearchable || !showSearchBox ? "" : (
           <div css={{
             display: 'flex',
+            justifyContent: 'center',
           }}>
             <SearchBox
               autoFocus={autoFocusSearchBox}
@@ -804,7 +807,7 @@ function CheckboxTree<T> (props: CheckboxTreeProps<T>) {
         {noResultsMessage}
         {wrapTreeSection ? wrapTreeSection(treeSection) : treeSection}
         {linksPosition && linksPosition == LinksPosition.Bottom ? treeLinks : null}
-      </div>
+      </>
     );
 }
 

--- a/src/components/inputs/checkboxes/CheckboxTree/CheckboxTreeNode.tsx
+++ b/src/components/inputs/checkboxes/CheckboxTree/CheckboxTreeNode.tsx
@@ -147,7 +147,7 @@ export default function CheckboxTreeNode<T>({
           )}
           {!isSelectable || (!isMultiPick && !isLeafNode) ? (
             <div
-              css={{width: '100%'}}
+              css={{width: '100%', margin: 'auto 0'}}
               onClick={shouldExpandOnClick ? () => toggleExpansion(node) : undefined}
               >
               {nodeElement}

--- a/src/components/inputs/checkboxes/CheckboxTree/CheckboxTreeNode.tsx
+++ b/src/components/inputs/checkboxes/CheckboxTree/CheckboxTreeNode.tsx
@@ -153,14 +153,22 @@ export default function CheckboxTreeNode<T>({
               {nodeElement}
             </div>
           ) : (
-            <label>
+            <label css={{
+              display: 'flex',
+              width: '100%',
+            }}>
               {CustomCheckbox ? <CustomCheckbox {...checkboxProps} /> : isMultiPick
                   ? <IndeterminateCheckbox {...checkboxProps} />
                   : <TreeRadio
                       {...commonInputProps}
                       onChange={toggleSelection}
                     />
-              } {nodeElement}
+              } 
+              <div
+                css={{width: '100%', margin: 'auto 0'}}
+              >
+                {nodeElement}
+              </div>
             </label>
           )}
         </div>

--- a/src/components/inputs/checkboxes/CheckboxTree/CheckboxTreeNode.tsx
+++ b/src/components/inputs/checkboxes/CheckboxTree/CheckboxTreeNode.tsx
@@ -10,6 +10,7 @@ export type CheckboxListStyleSpec = {
   },
   children: {
     padding: CSSProperties['padding']
+    margin: CSSProperties['margin']
   },
 };
 
@@ -19,6 +20,7 @@ const defaultStyle = {
   },
   children: {
     padding: '0 0 0 1.5em',
+    margin: 0,
   },
 }
 
@@ -156,6 +158,7 @@ export default function CheckboxTreeNode<T>({
             <label css={{
               display: 'flex',
               width: '100%',
+              marginLeft: isLeafNode ? '1em' : 0,
             }}>
               {CustomCheckbox ? <CustomCheckbox {...checkboxProps} /> : isMultiPick
                   ? <IndeterminateCheckbox {...checkboxProps} />


### PR DESCRIPTION
These changes were brought on while implementing the new `Select*` and `Checkbox*` components in the following `web-eda` contexts:
1. the variable selectors in the viz tab
2. the browse and subset `CheckboxTree`
3. the download modal's `CheckboxTree`