### PR TITLE
Use generics in value prop type in SelectList, CheckboxList, and SingleSelect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/coreui",
-  "version": "0.18.9",
+  "version": "0.18.10",
   "author": "Michael Dunn <mdunn4@nd.edu>",
   "description": "Core components and style definitions for VEuPath applications.",
   "private": false,

--- a/src/components/inputs/SelectList.tsx
+++ b/src/components/inputs/SelectList.tsx
@@ -2,13 +2,13 @@ import { ReactNode, useEffect, useState } from "react";
 import PopoverButton from "../buttons/PopoverButton/PopoverButton";
 import CheckboxList, { CheckboxListProps } from "./checkboxes/CheckboxList";
   
-export interface SelectListProps extends CheckboxListProps {
+export interface SelectListProps<T> extends CheckboxListProps<T> {
     children?: ReactNode;
     /** A button's content if/when no values are currently selected */
     defaultButtonDisplayContent: ReactNode;
 }
 
-export default function SelectList({
+export default function SelectList<T>({
     name,
     items,
     value,
@@ -16,8 +16,8 @@ export default function SelectList({
     linksPosition,
     children,
     defaultButtonDisplayContent,
-}: SelectListProps) {
-    const [selected, setSelected] = useState<SelectListProps['value']>(value);
+}: SelectListProps<T>) {
+    const [selected, setSelected] = useState<SelectListProps<T>['value']>(value);
     const [ buttonDisplayContent, setButtonDisplayContent] = useState<ReactNode>(value.length ? value.join(', ') : defaultButtonDisplayContent);
 
     const onClose = () => {

--- a/src/components/inputs/SingleSelect.tsx
+++ b/src/components/inputs/SingleSelect.tsx
@@ -1,14 +1,11 @@
 import { ReactNode, useEffect, useState, useRef } from "react";
 import PopoverButton from "../buttons/PopoverButton/PopoverButton";
+import { Item } from "./checkboxes/CheckboxList";
 import { css } from '@emotion/react';
 import { uniqueId } from "lodash";
 
-export type SingleSelectItem<T> = {
-    display: ReactNode,
-    value: T,
-  }
 export interface SingleSelectProps<T> {
-    items: SingleSelectItem<T>[];
+    items: Item<T>[];
     value: T;
     onSelect: (value: T) => void;
     buttonDisplayContent: ReactNode;
@@ -87,7 +84,7 @@ export default function SingleSelect<T>({
 }
 
 interface OptionProps<T> {
-    item: SingleSelectItem<T>;
+    item: Item<T>;
     onSelect: (value: T) => void;
     onKeyDown: (key: string, value: T) => void;
     shouldFocus: boolean;

--- a/src/components/inputs/SingleSelect.tsx
+++ b/src/components/inputs/SingleSelect.tsx
@@ -5,8 +5,15 @@ import { css } from '@emotion/react';
 import { uniqueId } from "lodash";
 
 export interface SingleSelectProps<T> {
+    /** An array of options to be used in the dropdown container */
     items: Item<T>[];
+
+    /** 
+      * Warning: `value` represents the currently-selected value; for non-primitive types, `value` must be
+      * pointing to the same object reference as what's used in the `items` prop
+    */
     value: T;
+
     onSelect: (value: T) => void;
     buttonDisplayContent: ReactNode;
 }

--- a/src/components/inputs/SingleSelect.tsx
+++ b/src/components/inputs/SingleSelect.tsx
@@ -1,13 +1,16 @@
 import { ReactNode, useEffect, useState, useRef } from "react";
 import PopoverButton from "../buttons/PopoverButton/PopoverButton";
-import { Item } from "./checkboxes/CheckboxList";
 import { css } from '@emotion/react';
 import { uniqueId } from "lodash";
-  
+
+export type SingleSelectItem = {
+    display: ReactNode
+    value: any
+  }
 export interface SingleSelectProps {
-    items: Item[];
-    value: string;
-    onSelect: (value: string) => void;
+    items: SingleSelectItem[];
+    value: any;
+    onSelect: (value: any) => void;
     buttonDisplayContent: ReactNode;
 }
 
@@ -29,7 +32,7 @@ export default function SingleSelect({
 
     const [ key, setKey ] = useState<string>('');
 
-    const handleSelection = (newValue: string) => {
+    const handleSelection = (newValue: any) => {
         onSelect(newValue);
         setKey(uniqueId());
     }
@@ -39,7 +42,7 @@ export default function SingleSelect({
         setIndexOfFocusedElement(defaultOrSelectedValueIndex)
     }, [defaultOrSelectedValueIndex])
 
-    const onKeyDown = (key: string, newValue: string) => {
+    const onKeyDown = (key: string, newValue: any) => {
         if (!isPopoverOpen) return;
         if (key === 'Enter') {
             handleSelection(newValue)
@@ -68,7 +71,7 @@ export default function SingleSelect({
             >
                 {items.map((item, index) => (
                     <Option 
-                        key={item.value}
+                        key={JSON.stringify(item.value)}
                         item={item} 
                         onSelect={handleSelection} 
                         onKeyDown={onKeyDown} 
@@ -84,9 +87,9 @@ export default function SingleSelect({
 }
 
 interface OptionProps {
-    item: Item;
-    onSelect: (value: string) => void;
-    onKeyDown: (key: string, value: string) => void;
+    item: SingleSelectItem;
+    onSelect: (value: any) => void;
+    onKeyDown: (key: string, value: any) => void;
     shouldFocus: boolean;
     isSelected: boolean;
 }
@@ -109,7 +112,6 @@ function Option({
             role="option"
             aria-selected={isSelected}
             ref={optionRef}
-            key={item.value}
             css={css`
                 padding: 0.5em;
                 line-height: 1.25;

--- a/src/components/inputs/SingleSelect.tsx
+++ b/src/components/inputs/SingleSelect.tsx
@@ -3,23 +3,23 @@ import PopoverButton from "../buttons/PopoverButton/PopoverButton";
 import { css } from '@emotion/react';
 import { uniqueId } from "lodash";
 
-export type SingleSelectItem = {
-    display: ReactNode
-    value: any
+export type SingleSelectItem<T> = {
+    display: ReactNode,
+    value: T,
   }
-export interface SingleSelectProps {
-    items: SingleSelectItem[];
-    value: any;
-    onSelect: (value: any) => void;
+export interface SingleSelectProps<T> {
+    items: SingleSelectItem<T>[];
+    value: T;
+    onSelect: (value: T) => void;
     buttonDisplayContent: ReactNode;
 }
 
-export default function SingleSelect({
+export default function SingleSelect<T>({
     items,
     value,
     onSelect,
     buttonDisplayContent,
-}: SingleSelectProps) {
+}: SingleSelectProps<T>) {
     const [ isPopoverOpen, setIsPopoverOpen ] = useState<boolean>(false);
 
     /** 
@@ -32,7 +32,7 @@ export default function SingleSelect({
 
     const [ key, setKey ] = useState<string>('');
 
-    const handleSelection = (newValue: any) => {
+    const handleSelection = (newValue: T) => {
         onSelect(newValue);
         setKey(uniqueId());
     }
@@ -42,7 +42,7 @@ export default function SingleSelect({
         setIndexOfFocusedElement(defaultOrSelectedValueIndex)
     }, [defaultOrSelectedValueIndex])
 
-    const onKeyDown = (key: string, newValue: any) => {
+    const onKeyDown = (key: string, newValue: T) => {
         if (!isPopoverOpen) return;
         if (key === 'Enter') {
             handleSelection(newValue)
@@ -70,7 +70,7 @@ export default function SingleSelect({
                 }}
             >
                 {items.map((item, index) => (
-                    <Option 
+                    <Option<T> 
                         key={JSON.stringify(item.value)}
                         item={item} 
                         onSelect={handleSelection} 
@@ -86,21 +86,21 @@ export default function SingleSelect({
     )
 }
 
-interface OptionProps {
-    item: SingleSelectItem;
-    onSelect: (value: any) => void;
-    onKeyDown: (key: string, value: any) => void;
+interface OptionProps<T> {
+    item: SingleSelectItem<T>;
+    onSelect: (value: T) => void;
+    onKeyDown: (key: string, value: T) => void;
     shouldFocus: boolean;
     isSelected: boolean;
 }
 
-function Option({
+function Option<T>({
     item, 
     onSelect, 
     onKeyDown,
     shouldFocus,
     isSelected
-}: OptionProps) {
+}: OptionProps<T>) {
     const optionRef = useRef<HTMLLIElement>(null);
 
     if (shouldFocus && optionRef.current) {

--- a/src/components/inputs/checkboxes/CheckboxList.tsx
+++ b/src/components/inputs/checkboxes/CheckboxList.tsx
@@ -69,22 +69,22 @@ enum LinksPosition {
   Both = Top | Bottom
 }
 
-export type Item = {
-  display: ReactNode
-  value: string
+export type Item<T> = {
+  display: ReactNode,
+  value: T,
 }
 
-export type CheckboxListProps = {
+export type CheckboxListProps<T> = {
   /** Optional name attribute for the native input element */
   name?: string;
 
   /** The items available for selection in the checkbox list */
-  items: Item[];
+  items: Item<T>[];
 
   /** An array of item values currently selected */
-  value: string[];
+  value: T[];
 
-  onChange: (value: string[]) => void;
+  onChange: (value: T[]) => void;
   
   /**  Controls location of the "select all" and "clear all" buttons */
   linksPosition?: LinksPosition;
@@ -93,7 +93,7 @@ export type CheckboxListProps = {
   styleOverrides?: Partial<CheckboxListStyleSpec>;
 }
 
-export default function CheckboxList({
+export default function CheckboxList<T>({
     name,
     items,
     value,
@@ -101,7 +101,7 @@ export default function CheckboxList({
     linksPosition = LinksPosition.Bottom,
     themeRole,
     styleOverrides
-}: CheckboxListProps) {
+}: CheckboxListProps<T>) {
 
   const theme = useUITheme();
   const themeStyle = useMemo<Partial<CheckboxListStyleSpec>>(
@@ -142,7 +142,7 @@ export default function CheckboxList({
     </div>
   );
 
-  const onChangeHandler = (valueChanged: string) => {
+  const onChangeHandler = (valueChanged: T) => {
     const availableSelections = items.map(item => item.value);
     onChange(
       value.indexOf(valueChanged) == -1 ?
@@ -168,7 +168,7 @@ export default function CheckboxList({
         {items.map(item => {
           return (
             <div 
-              key={item.value}
+              key={JSON.stringify(item.value)}
               css={{
                 margin: finalStyle.options.margin,
                 color: finalStyle.options.color,
@@ -179,7 +179,7 @@ export default function CheckboxList({
                 <input
                   type="checkbox"
                   name={name}
-                  value={item.value}
+                  value={JSON.stringify(item.value)}
                   checked={value.includes(item.value)}
                   onChange={() => onChangeHandler(item.value)}
                 />

--- a/src/components/inputs/checkboxes/CheckboxList.tsx
+++ b/src/components/inputs/checkboxes/CheckboxList.tsx
@@ -81,7 +81,10 @@ export type CheckboxListProps<T> = {
   /** The items available for selection in the checkbox list */
   items: Item<T>[];
 
-  /** An array of item values currently selected */
+  /** 
+    * Warning: An array of item values currently selected; for non-primitive types, the values must be
+    * pointing to the same object reference as what's used in the `items` prop
+  */
   value: T[];
 
   onChange: (value: T[]) => void;


### PR DESCRIPTION
In response to [feedback for the work in implementing `SingleSelect` in mbio's `alphaDiv` and `abundance` plugin configs](https://github.com/VEuPathDB/web-eda/pull/1394#pullrequestreview-1141785757).

By changing the type of the `value` prop of `SingleSelect` to be `any`, we greatly simplify this particular implementation by obviating the existing JSON stringifying and parsing.