### PR TITLE
Add ArrowDown and ArrowRight icons and add all icons to story

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/coreui",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "author": "Michael Dunn <mdunn4@nd.edu>",
   "description": "Core components and style definitions for VEuPath applications.",
   "private": false,

--- a/src/components/icons/ArrowDown.tsx
+++ b/src/components/icons/ArrowDown.tsx
@@ -1,0 +1,18 @@
+import { SVGProps } from "react";
+
+const ArrowDown = (props: SVGProps<SVGSVGElement>) => {
+  const { height = '1em', width = '1em' } = props;
+  return (
+    <svg 
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="-16 176 352 224"
+      height={height}
+      width={width}
+    >
+      {/* Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. */}
+      <path d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9s-16.6-19.8-29.6-19.8L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"/>
+    </svg>
+  )
+};
+
+export default ArrowDown;

--- a/src/components/icons/ArrowRight.tsx
+++ b/src/components/icons/ArrowRight.tsx
@@ -1,0 +1,19 @@
+import { SVGProps } from "react";
+
+const ArrowRight = (props: SVGProps<SVGSVGElement>) => {
+    const { height = '1em', width = '1em' } = props;
+    return (
+        <svg 
+            xmlns="http://www.w3.org/2000/svg" 
+            viewBox="52 84 216 344"
+            height={height}
+            width={width}
+            {...props}
+        >
+            {/* Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. */}
+            <path d="M246.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-9.2-9.2-22.9-11.9-34.9-6.9s-19.8 16.6-19.8 29.6l0 256c0 12.9 7.8 24.6 19.8 29.6s25.7 2.2 34.9-6.9l128-128z"/>
+        </svg>
+    )
+}
+
+export default ArrowRight;

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -1,3 +1,5 @@
+export { default as ArrowDown } from "./ArrowDown";
+export { default as ArrowRight } from "./ArrowRight";
 export { default as CheckIcon } from "./CheckIcon";
 export { default as CheckCircle } from "./CheckCircle";
 export { default as ChevronRight } from "./ChevronRight";

--- a/src/stories/typography/Icons.stories.tsx
+++ b/src/stories/typography/Icons.stories.tsx
@@ -9,6 +9,34 @@ import {
   DoubleArrow,
   Cancel,
 } from "../../assets/icons";
+import {
+  ArrowDown,
+  ArrowRight,
+  CheckIcon,
+  CheckCircle,
+  ChevronRight,
+  Close,
+  CloseCircle,
+  CloseFullscreen,
+  Copy,
+  Download,
+  EdaIcon,
+  Edit,
+  Filter,
+  Loading,
+  NoEdit,
+  Pencil,
+  SampleDetailsDark,
+  SampleDetailsLight,
+  Share,
+  TableDownload,
+  Table,
+  TaxaQueryDark,
+  TaxaQueryLight,
+  Trash,
+  Undo,
+  Warning,
+} from "../../components/icons";
 import { gray } from "../../definitions/colors";
 import { H5 } from "../../components/typography";
 import { grey } from "@material-ui/core/colors";
@@ -42,6 +70,7 @@ const IconDisplay = ({
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
+        rowGap: 10,
       }}
     >
       <div>
@@ -64,12 +93,12 @@ const IconDisplay = ({
 export const AllIcons: Story<IconProps> = (args) => {
   return (
     <div>
-      <H5>Icons</H5>
+      <H5 additionalStyles={{margin: '0.75em 0'}}>Icons</H5>
       <div
         style={{
-          display: "flex",
-          // gap: 20,
-          justifyContent: "space-evenly",
+          display: "grid",
+          gap: 40,
+          gridTemplateColumns: 'repeat(6, auto)',
           padding: 20,
           backgroundColor: grey[200],
           borderRadius: 10,
@@ -78,10 +107,36 @@ export const AllIcons: Story<IconProps> = (args) => {
         }}
       >
         <IconDisplay {...args} name="Arrow" component={Arrow} />
+        <IconDisplay {...args} name="ArrowDown" component={ArrowDown} />
+        <IconDisplay {...args} name="ArrowRight" component={ArrowRight} />
         <IconDisplay {...args} name="Cancel" component={Cancel} />
         <IconDisplay {...args} name="CaretDown" component={CaretDown} />
         <IconDisplay {...args} name="CaretUp" component={CaretUp} />
+        <IconDisplay {...args} name="CheckCircle" component={CheckCircle} />
+        <IconDisplay {...args} name="CheckIcon" component={CheckIcon} />
+        <IconDisplay {...args} name="ChevronRight" component={ChevronRight} />
+        <IconDisplay {...args} name="Close" component={Close} />
+        <IconDisplay {...args} name="CloseCircle" component={CloseCircle} />
+        <IconDisplay {...args} name="CloseFullscreen" component={CloseFullscreen} />
+        <IconDisplay {...args} name="Copy" component={Copy} />
         <IconDisplay {...args} name="DoubleArrow" component={DoubleArrow} />
+        <IconDisplay {...args} name="Download" component={Download} />
+        <IconDisplay {...args} name="EdaIcon" component={EdaIcon} />
+        <IconDisplay {...args} name="Edit" component={Edit} />
+        <IconDisplay {...args} name="Filter" component={Filter} />
+        <IconDisplay {...args} name="Loading" component={Loading} />
+        <IconDisplay {...args} name="NoEdit" component={NoEdit} />
+        <IconDisplay {...args} name="Pencil" component={Pencil} />
+        <IconDisplay {...args} name="SampleDetailsDark" component={SampleDetailsDark} />
+        <IconDisplay {...args} name="SampleDetailsLight" component={SampleDetailsLight} />
+        <IconDisplay {...args} name="Share" component={Share} />
+        <IconDisplay {...args} name="TableDownload" component={TableDownload} />
+        <IconDisplay {...args} name="Table" component={Table} />
+        <IconDisplay {...args} name="TaxaQueryDark" component={TaxaQueryDark} />
+        <IconDisplay {...args} name="TaxaQueryLight" component={TaxaQueryLight} />
+        <IconDisplay {...args} name="Trash" component={Trash} />
+        <IconDisplay {...args} name="Undo" component={Undo} />
+        <IconDisplay {...args} name="Warning" component={Warning} />
       </div>
     </div>
   );


### PR DESCRIPTION
This PR adds two new icons to be used in the `CheckboxTree` expand/collapse toggles: `ArrowDown` and `ArrowRight`. During this work, I also added all icons to the `Typography/Icons` story.