### PR TITLE
Spread props into ArrowDown icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/coreui",
-  "version": "0.18.8",
+  "version": "0.18.9",
   "author": "Michael Dunn <mdunn4@nd.edu>",
   "description": "Core components and style definitions for VEuPath applications.",
   "private": false,

--- a/src/components/icons/ArrowDown.tsx
+++ b/src/components/icons/ArrowDown.tsx
@@ -8,6 +8,7 @@ const ArrowDown = (props: SVGProps<SVGSVGElement>) => {
       viewBox="-16 176 352 224"
       height={height}
       width={width}
+      {...props}
     >
       {/* Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. */}
       <path d="M137.4 374.6c12.5 12.5 32.8 12.5 45.3 0l128-128c9.2-9.2 11.9-22.9 6.9-34.9s-16.6-19.8-29.6-19.8L32 192c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9l128 128z"/>


### PR DESCRIPTION
Fixes an error in which props weren't spread into the `ArrowDown` icon's SVG.