### PR TITLE
add show more function to Banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/coreui",
-  "version": "0.18.11",
+  "version": "0.18.12",
   "author": "Michael Dunn <mdunn4@nd.edu>",
   "description": "Core components and style definitions for VEuPath applications.",
   "private": false,

--- a/src/components/banners/Banner.tsx
+++ b/src/components/banners/Banner.tsx
@@ -15,14 +15,14 @@ export type BannerProps = {
   message: ReactNode;
   pinned?: boolean;
   intense?: boolean;
-  // activate showMore feature
-  showMore?: boolean;
   // text for showMore link
   showMoreLinkText?: ReactNode;
   // text for showless link
   showLessLinkText?: ReactNode;
-  // additionalMessage is shown next to message when clicking showMoreLinkText
+  // additionalMessage is shown next to message when clicking showMoreLinkText.
   // disappears when clicking showLess link
+  // note that this additionalMessage prop is used to determine show more/less behavior or not
+  // if undefined, then just show normal banner with message
   additionalMessage?: ReactNode;
 }
 
@@ -69,7 +69,8 @@ function getColorTheme(type: BannerProps['type'], weight: keyof ColorHue) {
 
 export default function Banner(props: BannerComponentProps) {
   const { banner, onClose } = props;
-  const { type, message, pinned, intense, showMore, showMoreLinkText, showLessLinkText, additionalMessage } = banner;
+  // set default values of showMoreLinkText and showLessLinkText
+  const { type, message, pinned, intense, showMoreLinkText = 'Show more >>', showLessLinkText = 'Show less <<', additionalMessage } = banner;
 
   const [isShowMore, setIsShowMore] = useState(false);
 
@@ -110,7 +111,7 @@ export default function Banner(props: BannerComponentProps) {
       `}>
         {/* showMore implementation */}
         {message}&nbsp;
-        {showMore && (
+        {additionalMessage != null && (
           <>
             {isShowMore && additionalMessage}
             <button

--- a/src/components/banners/Banner.tsx
+++ b/src/components/banners/Banner.tsx
@@ -81,6 +81,11 @@ export default function Banner(props: BannerComponentProps) {
   // define showMore link texts
   const showMoreLink = isShowMore ? showLessLinkText : showMoreLinkText;
 
+  //DKDK hover effect
+  const [isHover, setIsHover] = useState(false);
+  const onMouseEnter = () => { setIsHover(true); };
+  const onMouseLeave = () => { setIsHover(false); };
+
   return (
     <div
       css={css`
@@ -119,11 +124,9 @@ export default function Banner(props: BannerComponentProps) {
             <button
               css={css`
                 background-color: transparent;
-                // border: 0px solid #ffffff;
                 border: none;
                 text-align: center;
-                //text-decoration: underline;
-                // color: ${showMoreLinkColor != null ? showMoreLinkColor : undefined};
+                text-decoration: ${isHover ? 'underline' : 'none' };
                 color: ${showMoreLinkColor};
                 display: inline-block;
                 cursor: pointer;
@@ -131,6 +134,8 @@ export default function Banner(props: BannerComponentProps) {
               onClick={() => {
                 setIsShowMore != null ? setIsShowMore(!isShowMore) : null;
               }}
+              onMouseEnter={onMouseEnter}
+              onMouseLeave={onMouseLeave}
             >
               {showMoreLink}
             </button>

--- a/src/components/banners/Banner.tsx
+++ b/src/components/banners/Banner.tsx
@@ -15,17 +15,17 @@ export type BannerProps = {
   message: ReactNode;
   pinned?: boolean;
   intense?: boolean;
+  // additionalMessage is shown next to message when clicking showMoreLinkText.
+  // disappears when clicking showLess link
+  // note that this additionalMessage prop is used to determine show more/less behavior or not
+  // if undefined, then just show normal banner with message
+  additionalMessage?: ReactNode;
   // text for showMore link
   showMoreLinkText?: ReactNode;
   // text for showless link
   showLessLinkText?: ReactNode;
   // color for show more links
   showMoreLinkColor?: string;
-  // additionalMessage is shown next to message when clicking showMoreLinkText.
-  // disappears when clicking showLess link
-  // note that this additionalMessage prop is used to determine show more/less behavior or not
-  // if undefined, then just show normal banner with message
-  additionalMessage?: ReactNode;
 }
 
 export type BannerComponentProps = {

--- a/src/components/banners/Banner.tsx
+++ b/src/components/banners/Banner.tsx
@@ -19,6 +19,8 @@ export type BannerProps = {
   showMoreLinkText?: ReactNode;
   // text for showless link
   showLessLinkText?: ReactNode;
+  // color for show more links
+  showMoreLinkColor?: string;
   // additionalMessage is shown next to message when clicking showMoreLinkText.
   // disappears when clicking showLess link
   // note that this additionalMessage prop is used to determine show more/less behavior or not
@@ -70,7 +72,7 @@ function getColorTheme(type: BannerProps['type'], weight: keyof ColorHue) {
 export default function Banner(props: BannerComponentProps) {
   const { banner, onClose } = props;
   // set default values of showMoreLinkText and showLessLinkText
-  const { type, message, pinned, intense, showMoreLinkText = 'Show more >>', showLessLinkText = 'Show less <<', additionalMessage } = banner;
+  const { type, message, pinned, intense, showMoreLinkText = 'Show more >>', showLessLinkText = 'Show less <<', showMoreLinkColor, additionalMessage } = banner;
 
   const [isShowMore, setIsShowMore] = useState(false);
 
@@ -120,7 +122,9 @@ export default function Banner(props: BannerComponentProps) {
                 // border: 0px solid #ffffff;
                 border: none;
                 text-align: center;
-                text-decoration: underline;
+                //text-decoration: underline;
+                // color: ${showMoreLinkColor != null ? showMoreLinkColor : undefined};
+                color: ${showMoreLinkColor};
                 display: inline-block;
                 cursor: pointer;
               `}

--- a/src/components/banners/Banner.tsx
+++ b/src/components/banners/Banner.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 
 import WarningIcon from '@material-ui/icons/Warning';
 import ErrorIcon from '@material-ui/icons/Error';
@@ -15,6 +15,15 @@ export type BannerProps = {
   message: ReactNode;
   pinned?: boolean;
   intense?: boolean;
+  // activate showMore feature
+  showMore?: boolean;
+  // text for showMore link
+  showMoreLinkText?: string;
+  // text for showless link
+  showLessLinkText?: string;
+  // additionalMessage is shown next to message when clicking showMoreLinkText
+  // disappears when clicking showLess link
+  additionalMessage?: string;
 }
 
 export type BannerComponentProps = {
@@ -60,9 +69,14 @@ function getColorTheme(type: BannerProps['type'], weight: keyof ColorHue) {
 
 export default function Banner(props: BannerComponentProps) {
   const { banner, onClose } = props;
-  const { type, message, pinned, intense } = banner;
+  const { type, message, pinned, intense, showMore, showMoreLinkText, showLessLinkText, additionalMessage } = banner;
+
+  const [isShowMore, setIsShowMore] = useState(false);
 
   const IconComponent = getIconComponentFromType(type);
+
+  // define showMore link texts
+  const showMoreLink = isShowMore ? showLessLinkText : showMoreLinkText;
 
   return (
     <div
@@ -94,7 +108,30 @@ export default function Banner(props: BannerComponentProps) {
       <span css={css`
         margin-right: auto;
       `}>
-        {message}
+        {/* showMore implementation */}
+        {message}&nbsp;
+        {showMore && (
+          <>
+            {isShowMore && additionalMessage}
+            <button
+              css={css`
+                background-color: transparent;
+                // border: 0px solid #ffffff;
+                border: none;
+                text-align: center;
+                text-decoration: underline;
+                display: inline-block;
+                cursor: pointer;
+              `}
+              onClick={() => {
+                setIsShowMore != null ? setIsShowMore(!isShowMore) : null;
+              }}
+            >
+              {showMoreLink}
+            </button>
+          </>
+        )}
+
       </span>
       {pinned || !onClose ? null : (
         <a

--- a/src/components/banners/Banner.tsx
+++ b/src/components/banners/Banner.tsx
@@ -81,7 +81,7 @@ export default function Banner(props: BannerComponentProps) {
   // define showMore link texts
   const showMoreLink = isShowMore ? showLessLinkText : showMoreLinkText;
 
-  //DKDK hover effect
+  // hover effect
   const [isHover, setIsHover] = useState(false);
   const onMouseEnter = () => { setIsHover(true); };
   const onMouseLeave = () => { setIsHover(false); };

--- a/src/components/banners/Banner.tsx
+++ b/src/components/banners/Banner.tsx
@@ -18,12 +18,12 @@ export type BannerProps = {
   // activate showMore feature
   showMore?: boolean;
   // text for showMore link
-  showMoreLinkText?: string;
+  showMoreLinkText?: ReactNode;
   // text for showless link
-  showLessLinkText?: string;
+  showLessLinkText?: ReactNode;
   // additionalMessage is shown next to message when clicking showMoreLinkText
   // disappears when clicking showLess link
-  additionalMessage?: string;
+  additionalMessage?: ReactNode;
 }
 
 export type BannerComponentProps = {

--- a/src/stories/notifications/Banners.stories.tsx
+++ b/src/stories/notifications/Banners.stories.tsx
@@ -115,7 +115,7 @@ export const ShowMore = (args) => {
             // activate showMore feature
             showMore: isShowMore,
             // text for showMore link
-            showMoreLinkText: 'Why ?',
+            showMoreLinkText: 'Why?',
             // text for showless link
             showLessLinkText: 'Read less',
             // additionalMessage is shown next to message when clicking showMoreLinkText.

--- a/src/stories/notifications/Banners.stories.tsx
+++ b/src/stories/notifications/Banners.stories.tsx
@@ -112,12 +112,6 @@ export const ShowMore = (args) => {
             message: 'Smoothed mean(s) were not calculated for one or more data series.',
             pinned: false,
             intense: false,
-            // text for showMore link
-            showMoreLinkText: 'Why?',
-            // text for showless link
-            showLessLinkText: 'Read less',
-            // color for show more links
-            showMoreLinkColor: '#006699',
             // additionalMessage is shown next to message when clicking showMoreLinkText.
             // disappears when clicking showLess link
             // note that this additionalMessage prop is used to determine show more/less behavior or not
@@ -125,6 +119,12 @@ export const ShowMore = (args) => {
             additionalMessage: isShowMore
               ? 'The sample size might be too small or the data too skewed.'
               : undefined,
+            // text for showMore link
+            showMoreLinkText: 'Why?',
+            // text for showless link
+            showLessLinkText: 'Read less',
+            // color for show more links
+            showMoreLinkColor: '#006699',
           }}
           onClose={handleCloseWarning}
         />

--- a/src/stories/notifications/Banners.stories.tsx
+++ b/src/stories/notifications/Banners.stories.tsx
@@ -116,6 +116,8 @@ export const ShowMore = (args) => {
             showMoreLinkText: 'Why?',
             // text for showless link
             showLessLinkText: 'Read less',
+            // color for show more links
+            showMoreLinkColor: '#006699',
             // additionalMessage is shown next to message when clicking showMoreLinkText.
             // disappears when clicking showLess link
             // note that this additionalMessage prop is used to determine show more/less behavior or not

--- a/src/stories/notifications/Banners.stories.tsx
+++ b/src/stories/notifications/Banners.stories.tsx
@@ -115,7 +115,7 @@ export const ShowMore = (args) => {
             // activate showMore feature
             showMore: isShowMore,
             // text for showMore link
-            showMoreLinkText: ' Why ?',
+            showMoreLinkText: 'Why ?',
             // text for showless link
             showLessLinkText: 'Read less',
             // additionalMessage is shown next to message when clicking showMoreLinkText.

--- a/src/stories/notifications/Banners.stories.tsx
+++ b/src/stories/notifications/Banners.stories.tsx
@@ -1,8 +1,10 @@
+import React, { useState } from 'react'
 import { Story, Meta } from '@storybook/react/types-6-0';
 import UIThemeProvider from '../../components/theming/UIThemeProvider';
 import { gray } from '../../definitions/colors'
 
 import Banner, { BannerComponentProps } from '../../components/banners/Banner'
+import Toggle from '../../components/widgets/Toggle';
 
 export default {
     title: 'Notifications/Banners',
@@ -89,3 +91,48 @@ Normal.args = {
     },
     onClose: () => null
 } as BannerComponentProps;
+
+// testing showMore
+export const ShowMore = (args) => {
+  // set showMore state to provide a toggle for easy test
+  const [isShowMore, setIsShowMore] = useState(false);
+  // set useState to close Banner
+  const [shouldShowWarning, setShouldShowWarning] = useState<boolean>(true);
+  const handleCloseWarning = () => {
+    setShouldShowWarning(false);
+  };
+
+  return (
+    <div style={{width: '750px'}}>
+      {shouldShowWarning && (
+        <Banner
+          banner={{
+            type: 'warning',
+            // message is used as a basic text
+            message: 'Smoothed mean(s) were not calculated for one or more data series.',
+            pinned: false,
+            intense: false,
+            // activate showMore feature
+            showMore: isShowMore,
+            // text for showMore link
+            showMoreLinkText: ' Why ?',
+            // text for showless link
+            showLessLinkText: 'Read less',
+            // additionalMessage is shown next to message when clicking showMoreLinkText.
+            // disappears when clicking showLess link
+            additionalMessage: 'The sample size might be too small or the data too skewed.',
+          }}
+          onClose={handleCloseWarning}
+        />
+      )}
+      {/* showMore toggle for easily testing */}
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <Toggle
+          label="showMore option:"
+          value={isShowMore}
+          onChange={setIsShowMore}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/stories/notifications/Banners.stories.tsx
+++ b/src/stories/notifications/Banners.stories.tsx
@@ -112,15 +112,17 @@ export const ShowMore = (args) => {
             message: 'Smoothed mean(s) were not calculated for one or more data series.',
             pinned: false,
             intense: false,
-            // activate showMore feature
-            showMore: isShowMore,
             // text for showMore link
             showMoreLinkText: 'Why?',
             // text for showless link
             showLessLinkText: 'Read less',
             // additionalMessage is shown next to message when clicking showMoreLinkText.
             // disappears when clicking showLess link
-            additionalMessage: 'The sample size might be too small or the data too skewed.',
+            // note that this additionalMessage prop is used to determine show more/less behavior or not
+            // if undefined, then just show normal banner with message
+            additionalMessage: isShowMore
+              ? 'The sample size might be too small or the data too skewed.'
+              : undefined,
           }}
           onClose={handleCloseWarning}
         />


### PR DESCRIPTION
To address https://github.com/VEuPathDB/web-eda/issues/1423, Banner component needs to have show more/less like functionality. Also made a story to test it, with toggle button to enable/disable show more/less with ease, and added onClose function at the story to test. 

I have added @chowington and @jernestmyers as you are actively updating this CoreUI. Any suggestion on the name of props would be welcome 😃 

Here are screenshots:
- without showMore: typical message is shown
![coreui-showMore0](https://user-images.githubusercontent.com/12802305/197855183-a210a021-f797-46f0-9d27-048fd3bd6b09.png)

- with showMore: a link is provided to press (used Why? as the link)
![coreui-showMore1](https://user-images.githubusercontent.com/12802305/197855192-16f7d9f3-d6a4-4e50-9c20-b643d8690ac1.png)

- with showMore and pressing the showMore link: will show additional message and show less like link (used Read less)
![coreui-showMore2](https://user-images.githubusercontent.com/12802305/197855198-89db41c4-754d-4950-813d-8df2db1b3d65.png)
