### PR TITLE
change text colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/coreui",
-  "version": "0.18.12",
+  "version": "0.18.13",
   "author": "Michael Dunn <mdunn4@nd.edu>",
   "description": "Core components and style definitions for VEuPath applications.",
   "private": false,

--- a/src/components/grids/TabbedDisplay/index.tsx
+++ b/src/components/grids/TabbedDisplay/index.tsx
@@ -36,12 +36,12 @@ const DEFAULT_STYLE: TabbedDisplayStyleSpec = {
   },
   inactive: {
     backgroundColor: 'transparent',
-    textColor: gray[400],
+    textColor: gray[900],
     indicatorColor: 'transparent',
   },
   hover: {
     backgroundColor: 'transparent',
-    textColor: gray[400],
+    textColor: gray[900],
     indicatorColor: tan[300],
   },
   tabFontSize: '1em',
@@ -110,7 +110,7 @@ export default function TabbedDisplay<T extends string = string>({
     () => merge({}, DEFAULT_STYLE, themeStyle, styleOverrides),
     [themeStyle, styleOverrides]
   );
-  
+
   return (
     <div css={{ ...finalStyle.container }}>
       <div

--- a/src/components/grids/TabbedDisplay/index.tsx
+++ b/src/components/grids/TabbedDisplay/index.tsx
@@ -31,7 +31,7 @@ const DEFAULT_STYLE: TabbedDisplayStyleSpec = {
   },
   active: {
     backgroundColor: blue[100],
-    textColor: gray[600],
+    textColor: gray[900],
     indicatorColor: blue[500],
   },
   inactive: {


### PR DESCRIPTION
This is necessary to address https://github.com/VEuPathDB/web-eda/issues/998. I noticed that Jeremy used DARKEST_GRAY which is gray[900] for unifying text colors for log scale, etc. (https://github.com/VEuPathDB/web-components/pull/402) so I used the same color here. 

- A screenshot can be found in https://github.com/VEuPathDB/web-eda/pull/1461#issue-1435243262