### PR TITLE
Override eupathdb-Buttons class CSS in CheckboxList

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/coreui",
-  "version": "0.18.15",
+  "version": "0.18.16",
   "author": "Michael Dunn <mdunn4@nd.edu>",
   "description": "Core components and style definitions for VEuPath applications.",
   "private": false,

--- a/src/components/inputs/checkboxes/CheckboxList.tsx
+++ b/src/components/inputs/checkboxes/CheckboxList.tsx
@@ -126,6 +126,7 @@ export default function CheckboxList<T>({
   const linksHoverDecoration = css({
     textDecoration: 'underline',
     cursor: 'pointer',
+    background: 'none',
   })
 
   const linksStyles = {


### PR DESCRIPTION
This is a trivial change to ensure the hover effect on the links in `CheckboxList` do not inherit the global CSS style, which looks similar to a button's native hover effect.

Came to my attention while working on https://github.com/VEuPathDB/WDKClient/pull/264