### PR TITLE
add banner props to control spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/coreui",
-  "version": "0.18.16",
+  "version": "0.18.17",
   "author": "Michael Dunn <mdunn4@nd.edu>",
   "description": "Core components and style definitions for VEuPath applications.",
   "private": false,

--- a/src/components/banners/Banner.tsx
+++ b/src/components/banners/Banner.tsx
@@ -26,6 +26,12 @@ export type BannerProps = {
   showLessLinkText?: ReactNode;
   // color for show more links
   showMoreLinkColor?: string;
+  // banner margin, padding, text font size
+  spacing?: {
+    margin?: string,
+    padding?: string,
+  };
+  fontSize?: string;
 }
 
 export type BannerComponentProps = {
@@ -72,7 +78,7 @@ function getColorTheme(type: BannerProps['type'], weight: keyof ColorHue) {
 export default function Banner(props: BannerComponentProps) {
   const { banner, onClose } = props;
   // set default values of showMoreLinkText and showLessLinkText
-  const { type, message, pinned, intense, showMoreLinkText = 'Show more >>', showLessLinkText = 'Show less <<', showMoreLinkColor, additionalMessage } = banner;
+  const { type, message, pinned, intense, showMoreLinkText = 'Show more >>', showLessLinkText = 'Show less <<', showMoreLinkColor, additionalMessage, spacing, fontSize } = banner;
 
   const [isShowMore, setIsShowMore] = useState(false);
 
@@ -95,12 +101,12 @@ export default function Banner(props: BannerComponentProps) {
         border: ${intense ? 'none' : `1px solid ${getColorTheme(type, 600)}`};
         box-sizing: border-box;
         border-radius: 7px;
-        margin: 10px 0;
+        margin: ${spacing?.margin != null ? spacing.margin : '10px 0'};
         width: 100%;
-        padding: 10px;
+        padding: ${spacing?.padding != null ? spacing.padding : '10px'};
         align-items: center;
         font-family: 'Roboto', 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, freesans, sans-serif;
-        font-size: 13px;
+        font-size: ${fontSize != null ? fontSize : '13px'};
       `}
     >
       <IconComponent

--- a/src/components/banners/Banner.tsx
+++ b/src/components/banners/Banner.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { ReactNode, useState } from 'react';
+import { ReactNode, useState, CSSProperties } from 'react';
 
 import WarningIcon from '@material-ui/icons/Warning';
 import ErrorIcon from '@material-ui/icons/Error';
@@ -28,10 +28,10 @@ export type BannerProps = {
   showMoreLinkColor?: string;
   // banner margin, padding, text font size
   spacing?: {
-    margin?: string,
-    padding?: string,
+    margin?: CSSProperties['margin'],
+    padding?: CSSProperties['padding'],
   };
-  fontSize?: string;
+  fontSize?: CSSProperties['fontSize'];
 }
 
 export type BannerComponentProps = {

--- a/src/stories/notifications/Banners.stories.tsx
+++ b/src/stories/notifications/Banners.stories.tsx
@@ -125,6 +125,11 @@ export const ShowMore = (args) => {
             showLessLinkText: 'Read less',
             // color for show more links
             showMoreLinkColor: '#006699',
+            spacing: {
+              margin: '0.3125em 0',
+              padding: '0.3125em 0.625em',
+            },
+            fontSize: '0.8125em',
           }}
           onClose={handleCloseWarning}
         />


### PR DESCRIPTION
Following the request to narrow down the banner size from https://github.com/VEuPathDB/web-eda/issues/1502, I have added margin, padding, and font size props for use. Perhaps there may be better naming 