### PR TITLE
Add filteredList prop to CheckboxTree

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/coreui",
-  "version": "0.18.20",
+  "version": "0.18.21",
   "author": "Michael Dunn <mdunn4@nd.edu>",
   "description": "Core components and style definitions for VEuPath applications.",
   "private": false,

--- a/src/components/inputs/SelectTree/SelectTree.tsx
+++ b/src/components/inputs/SelectTree/SelectTree.tsx
@@ -38,6 +38,7 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
             expandedList={props.expandedList}
             isSelectable={props.isSelectable}
             selectedList={selectedList}
+            filteredList={props.filteredList}
             customCheckboxes={props.customCheckboxes}
             isMultiPick={props.isMultiPick}
             name={props.name}

--- a/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
+++ b/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
@@ -583,10 +583,10 @@ function createIsLeafVisible<T>(
   getNodeChildren: CheckboxTreeProps<T>['getNodeChildren'],
   isAdditionalFilterApplied: CheckboxTreeProps<T>['isAdditionalFilterApplied'],
   isSearchable: CheckboxTreeProps<T>['isSearchable'],
-  filteredList: CheckboxTreeProps<T>['filteredList'] = [],
+  filteredList: CheckboxTreeProps<T>['filteredList'],
 ) {
-  // if not searching and no filtered list is passed in, then all nodes are visible
-  if (!isActiveSearch(isAdditionalFilterApplied, isSearchable, searchTerm) && !filteredList.length) {
+  // if not searching, no additional filters are applied, and filteredList is undefined, then all nodes are visible
+  if (!isActiveSearch(isAdditionalFilterApplied, isSearchable, searchTerm) && !filteredList) {
     return (nodeId: string) => true;
   }
   // otherwise must construct array of visible leaves
@@ -599,12 +599,12 @@ function createIsLeafVisible<T>(
     if (parentMatches) {
       // if parent matches, automatically match (always show children of matching parents)
       nodeMatches = parentMatches;
-    } else if (searchTerm && filteredList.length) {
-      nodeMatches = searchPredicate(node, searchTerms) && filteredSet.has(nodeId)
-    } else if (!searchTerm && filteredList.length) {
-      nodeMatches = filteredSet.has(nodeId)
+    } else if (searchTerm && filteredList && filteredList.length) {
+      nodeMatches = searchPredicate(node, searchTerms) && filteredSet.has(nodeId);
+    } else if (!searchTerm && filteredList && filteredList.length) {
+      nodeMatches = filteredSet.has(nodeId);
     } else {
-      // handles filtering by search only (no filteredList is defined)
+      // handles filtering by search only (filteredList is undefined or an empty array)
       nodeMatches = searchPredicate(node, searchTerms)
     }
 
@@ -647,9 +647,7 @@ function CheckboxTree<T> (props: CheckboxTreeProps<T>) {
         getNodeId,
         getNodeChildren,
         searchTerm,
-        searchPredicate,
         selectedList,
-        filteredList = [],
         currentList,
         defaultList,
         isSearchable,
@@ -674,7 +672,6 @@ function CheckboxTree<T> (props: CheckboxTreeProps<T>) {
         wrapTreeSection,
         shouldExpandOnClick = true,
         customCheckboxes,
-        expandedList,
         renderNoResults,
         styleOverrides = {},
         customTreeNodeCssSelectors = {},

--- a/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
+++ b/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
@@ -151,7 +151,11 @@ export type CheckboxTreeProps<T> = {
   /** List of selected nodes as represented by their ids, defaults to [ ] */
   selectedList: string[];
 
-  /** List of filtered nodes as represented by their ids, defaults to [ ] */
+  /** 
+   * List of filtered nodes as represented by their ids used to determine isLeafVisible node status. 
+   * Refer to the documentation of the createIsLeafVisible function for a better understanding of its use and behavior.
+   * TL;DR: an empty array will render an empty tree whereas an undefined filteredList is ignored
+   * */
   filteredList?: string[];
 
   /** An object mapping a node (by its id) to a function that returns a React component. This component will be used instead of the default checkbox. */
@@ -569,7 +573,11 @@ function isFiltered(searchTerm: string, isAdditionalFilterApplied?: boolean) {
  * their ancestors, will be visible (expansion is locked and all branches are
  * expanded). Similar behavior exists when A) no search is being performed but 
  * a filtered list is provided and B) both a search is being performed and a
- * filtered list is provided.
+ * filtered list is provided. 
+ * 
+ * An important "gotcha" to consider: passing an empty array will render no tree
+ * based on the two `else-if` statements. If that is not desired, pass in an
+ * undefined filterList prop instead of an empty array.
  * 
  * The function returned by createIsLeafVisible does not care about
  * branches, but tells absolutely if a leaf should be visible (i.e. if the leaf
@@ -599,12 +607,12 @@ function createIsLeafVisible<T>(
     if (parentMatches) {
       // if parent matches, automatically match (always show children of matching parents)
       nodeMatches = parentMatches;
-    } else if (searchTerm && filteredList && filteredList.length) {
+    } else if (searchTerm && filteredList) {
       nodeMatches = searchPredicate(node, searchTerms) && filteredSet.has(nodeId);
-    } else if (!searchTerm && filteredList && filteredList.length) {
+    } else if (!searchTerm && filteredList) {
       nodeMatches = filteredSet.has(nodeId);
     } else {
-      // handles filtering by search only (filteredList is undefined or an empty array)
+      // handles filtering by search only (filteredList is undefined)
       nodeMatches = searchPredicate(node, searchTerms)
     }
 

--- a/src/definitions/animations.ts
+++ b/src/definitions/animations.ts
@@ -1,7 +1,7 @@
 import { keyframes } from '@emotion/react';
 import { Keyframes } from '@emotion/serialize';
 
-export const spin = keyframes({
+export const spin: Keyframes = keyframes({
   from: {
     transform: 'rotate(0deg)',
   },
@@ -10,7 +10,7 @@ export const spin = keyframes({
   },
 });
 
-export const fadeIn = keyframes({
+export const fadeIn: Keyframes = keyframes({
   from: {
     opacity: 0,
   },
@@ -19,7 +19,7 @@ export const fadeIn = keyframes({
   },
 });
 
-export const fadeOut = keyframes({
+export const fadeOut: Keyframes = keyframes({
   from: {
     opacity: 1,
   },


### PR DESCRIPTION
Allows filtering behavior that is similar to active search behavior. Parent component can pass in a list of node ids that are used to determine a node's `isLeafVisible` state.

Relates to https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/195